### PR TITLE
Bump `@actions/checkout` and `peter-evans/create-pull-request` versions

### DIFF
--- a/.github/workflows/process-form-submission.yml
+++ b/.github/workflows/process-form-submission.yml
@@ -12,7 +12,7 @@ jobs:
     name: Process Form
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Add new file to workspace
         run: "jq '.client_payload.form' $GITHUB_EVENT_PATH > _data/$REPOSITORY/submissions/$SUBMISSION_REF.json"
@@ -22,7 +22,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           commit-message: Add form submission
           committer: GitHub <noreply@github.com>


### PR DESCRIPTION
While investigating the list submission issue (#140), found that the following GitHub Actions need to be updated before upcoming deprecations also cause additional issues:

* Bump `actions/checkout@v2` -> `actions/checkout@v3`
* Bump `peter-evans/create-pull-request@v3` -> `peter-evans/create-pull-request@v4`