### PR TITLE
Fix "Documentation promotes accessibility" information not showing up for any entries

### DIFF
--- a/_includes/wai-authoring-tools-list/liquid/tool.liquid
+++ b/_includes/wai-authoring-tools-list/liquid/tool.liquid
@@ -331,7 +331,7 @@ _This tool listing was updated on {{ tool.submission_date | date: "%-d %B %Y" }}
 
 <dt>Documentation promotes accessibility</dt>
 <dd>
-{% if question-documentation-promotes-accessibility %}
+{% if tool.question-documentation-promotes-accessibility %}
 {{ tool.question-documentation-promotes-accessibility }}
 {% if tool.documentation-promotes-accessibility-partially-description != "" %}
 <div>Description: {{ tool.documentation-promotes-accessibility-partially-description }}</div>


### PR DESCRIPTION
All entries in the listing are currently marked "Documentation promotes accessibility: not provided" because of this bug. I didn’t test my changes, just replicated how other questions’ information is processed.