### PR TITLE
Update disclaimer: refer to 'authoring tools' instead of 'courses'

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -5,12 +5,12 @@ title: 'Authoring Tools List'
 permalink: /tools-list/authoring/
 ref: /tools-list/authoring/
 lang: en
+last_updated: 2025-02-12
 github:
   repository: w3c/wai-authoring-tools-list
   path: content/index.md
 description: Lists authoring tools with accessibility support. You can filter to find courses matching your specific interests.
 footer: >
-  <p><strong>Date:</strong> Updated 28 December 2022.</p>
   <p><strong>Previous Editor:</strong> Hidde de Vries. <strong>Contributors:</strong> Steve Lee, Shawn Lawton Henry, Kevin White, and <a href="https://www.w3.org/groups/wg/eowg/participants">EOWG Participants</a>.</p>
   <p>Developed by the Accessibility Education and Outreach Working Group (<a href="https://www.w3.org/groups/wg/eowg">EOWG</a>). Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide project</a>, co-funded by the European Commission.</p>
 ---

--- a/content/index.md
+++ b/content/index.md
@@ -80,13 +80,12 @@ footer: >
   </div>
 
   <div id="disclaimer">
-      {% include box.html type="start" title="<h3>Disclaimer</h3>" %}
-          <p><abbr title="World Wide Web Consortium">W3C</abbr> does not endorse specific vendor products. Inclusion of products in this list does not indicate endorsement by W3C. Products and search criteria are listed with no quality rating.</p>
-          <p>Tool descriptions, search criteria, and other information in this database is provided by tool developers, vendors, or others. W3C does not verify the accuracy of the information.</p>
-          <p>The list is not a review of authoring tools, nor a complete or definitive list of all tools. The information can change at any time.</p>
-      {% include box.html type="end" %}
+    {% include box.html type="start" title="Disclaimer" h="3" %}
+    <p><abbr title="World Wide Web Consortium">W3C</abbr> does not endorse specific vendor products. Inclusion of products in this list does not indicate endorsement by W3C. Products and search criteria are listed with no quality rating.</p>
+    <p>Tool descriptions, search criteria, and other information in this database is provided by tool developers, vendors, or others. W3C does not verify the accuracy of the information.</p>
+    <p>The list is not a review of authoring tools, nor a complete or definitive list of all tools. The information can change at any time.</p>
+    {% include box.html type="end" %}
   </div>
-
 
   <script>
     {% include wai-authoring-tools-list/js/tools.js %}

--- a/content/index.md
+++ b/content/index.md
@@ -81,7 +81,6 @@ footer: >
 
   <div id="disclaimer">
       {% include box.html type="start" title="<h3>Disclaimer</h3>" %}
-          <p>Information on this page is provided by vendors. <abbr title="World Wide Web Consortium">W3C</abbr> does not endorse specific products.</p>
           <p><abbr title="World Wide Web Consortium">W3C</abbr> does not endorse specific vendor products. Inclusion of products in this list does not indicate endorsement by W3C. Products and search criteria are listed with no quality rating.</p>
           <p>Tool descriptions, search criteria, and other information in this database is provided by tool developers, vendors, or others. W3C does not verify the accuracy of the information.</p>
           <p>The list is not a review of authoring tools, nor a complete or definitive list of all tools. The information can change at any time.</p>

--- a/content/index.md
+++ b/content/index.md
@@ -24,14 +24,14 @@ footer: >
   <div class="header-sup">
         <p>This list provides information on accessibility support in content management systems (CMS), learning management systems (LMS), web page editors, and other '<a href="https://www.w3.org/WAI/standards-guidelines/atag/#who-atag-is-for">authoring tools</a>'. The information is submitted by vendors and others. <abbr title="World Wide Web Consortium">W3C</abbr> does not verify the accuracy of the information. W3C does not endorse specific tools. See <a href="#disclaimer">Disclaimer</a>.</p>
         <a class="button button-more submit-a-tool" href="submit-a-tool"><span>Submit an authoring tool</span></a>
-</div> 
+</div>
 
   {% assign defaultSort = site.data.wai-authoring-tools-list.json.sorting.first.sortkey %}
   {% include wai-authoring-tools-list/liquid/sort-data-folder.liquid data=site.data.wai-authoring-tools-list.submissions sortKey=defaultSort %}
   <div id="app" >
 
   <div id="left-col" class="tools-filters">
-      
+
     <p>The <strong>Details</strong> section under the <strong>Tools</strong> listing has information on how the tool meets the web standard: <cite>Authoring Tool Accessibility Guidelines (<a href="https://www.w3.org/WAI/standards-guidelines/atag">ATAG</a>)</cite>. For a brief summary of ATAG, see <a href="https://www.w3.org/WAI/standards-guidelines/atag/glance/">ATAG at a Glance</a>.</p>
 
     <p>License type options are:</p>
@@ -78,14 +78,16 @@ footer: >
   <div class="button-submit-end">
   <a class="button button-more submit-a-tool" href="submit-a-tool"><span>Submit an authoring tool</span></a>
   </div>
-  
+
   <div id="disclaimer">
-  {% include box.html type="start" title="Disclaimer:"%}
-  <p><abbr title="World Wide Web Consortium">W3C</abbr> does not endorse specific providers or courses. Inclusion of courses in this list does not indicate endorsement by W3C. Courses and search criteria are listed with no quality rating.</p>
-  <p>Courses descriptions, search criteria, and other information in this database are submitted by providers. W3C does not verify the accuracy of the information.</p>
-  <p>The list is not a review of courses, nor a complete or definitive list of all courses. The information can change at any time.</p>
-  {% include box.html type="end" %}
+      {% include box.html type="start" title="<h3>Disclaimer</h3>" %}
+          <p>Information on this page is provided by vendors. <abbr title="World Wide Web Consortium">W3C</abbr> does not endorse specific products.</p>
+          <p><abbr title="World Wide Web Consortium">W3C</abbr> does not endorse specific vendor products. Inclusion of products in this list does not indicate endorsement by W3C. Products and search criteria are listed with no quality rating.</p>
+          <p>Tool descriptions, search criteria, and other information in this database is provided by tool developers, vendors, or others. W3C does not verify the accuracy of the information.</p>
+          <p>The list is not a review of authoring tools, nor a complete or definitive list of all tools. The information can change at any time.</p>
+      {% include box.html type="end" %}
   </div>
+
 
   <script>
     {% include wai-authoring-tools-list/js/tools.js %}

--- a/updatemods.sh
+++ b/updatemods.sh
@@ -1,1 +1,0 @@
-git submodule update --init --remote


### PR DESCRIPTION
[Direct link to preview](https://deploy-preview-196--wai-authoring-tools-list.netlify.app/tools-list/authoring/#disclaimer)

- Used the text from the [Evaluation Tools List disclaimer](https://www.w3.org/WAI/test-evaluate/tools/list/#disclaimer) and changed "evaluation tools" into "authoring tools".
- Changed the last update date, using the `last_updated` frontmatter attribute
- Deleted an unnecessary file